### PR TITLE
Add Cursor Cloud agent notes for Linux CLI development

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "AutoRename-PDF",
+  "install": "sudo apt-get update -qq\nsudo apt-get install -y -qq python3.12-venv\npython3 -m venv venv\n./venv/bin/pip install -r requirements.txt -r requirements-dev.txt\n./venv/bin/python tests/generate_test_pdfs.py"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,7 @@ See `CLAUDE.md` and `README.md` for architecture, providers, and standard comman
 ### Secrets
 
 - Optional for unit tests. Required for live cloud providers: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc. (see `.env.example`). Never commit `config.yaml` or `.env`.
+
+### Environment config
+
+- Cloud install is defined in `.cursor/environment.json` (repo-managed). Prefer merging that over the dashboard Save form when the form hangs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Agent notes
+
+See `CLAUDE.md` and `README.md` for architecture, providers, and standard commands.
+
+## Cursor Cloud specific instructions
+
+### Scope on Linux cloud VMs
+
+- Primary product for cloud agents: **Python CLI** (`autorename-pdf.py`).
+- **GUI / Tauri** (`gui/`) and Windows context-menu EXE are Windows-only; do not expect them to run in Linux cloud VMs.
+- Always use the project venv: `source venv/bin/activate` (or `./venv/bin/python ...`).
+
+### Dependencies & fixtures
+
+- Install refresh is handled by the environment update/install script (venv + `requirements.txt` / `requirements-dev.txt`).
+- PDF fixtures under `tests/fixtures/` are gitignored; regenerate with `python tests/generate_test_pdfs.py` before pytest if missing.
+- Copy configs locally (never commit): `cp config.yaml.example config.yaml` and optionally `cp harmonized-company-names.yaml.example harmonized-company-names.yaml`.
+
+### Lint / test / run
+
+- Tests: `pytest tests/ -v --cov` (see `.claude/skills/test/SKILL.md`).
+- Expected on Linux: `test_paddleocr_path_autodetect` fails — it patches Windows `LOCALAPPDATA`; Linux uses `~/.local/share` (see `_config_loader.py`). Treat as platform-specific, not a broken env.
+- Live provider tests need `--run-live` plus API keys in `.env` or Ollama; unit/mocked suite does not.
+- CLI: `python autorename-pdf.py rename <path> --dry-run --output json` then rename without `--dry-run`.
+- Offline end-to-end without cloud API keys: install/start Ollama separately (`ollama serve` in tmux if systemd is unavailable), pull a small model (e.g. `llama3.2:3b`), set `ai.provider: ollama` in `config.yaml`. Ollama is optional — not part of the default install script.
+
+### Secrets
+
+- Optional for unit tests. Required for live cloud providers: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc. (see `.env.example`). Never commit `config.yaml` or `.env`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes Cloud Agent setup **repo-managed** via `.cursor/environment.json`, and adds `AGENTS.md` notes for Linux cloud VMs.

## Why

The dashboard Save form can hang on “Preparing save form…” for transitional override environments (no `propose-environment-json` / no environment URL). Committing the validated install script in-repo is the reliable path.

## Install script (in `.cursor/environment.json`)

```
sudo apt-get update -qq
sudo apt-get install -y -qq python3.12-venv
python3 -m venv venv
./venv/bin/pip install -r requirements.txt -r requirements-dev.txt
./venv/bin/python tests/generate_test_pdfs.py
```

## Validated earlier

- Draft build `bld-20260820-bb7adfa1-32ce-4657-ba23-20dea08e1e61` succeeded with this install
- Fresh agent: 317 passed / 1 Windows-only fail / 36 skipped
- Hello-world Ollama rename worked

## Action

Merge this PR. New Cloud Agents started from this branch (or `main` after merge) will pick up `.cursor/environment.json` automatically — no dashboard Save required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f220e37d-333c-43d6-8df5-9b2981992efc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f220e37d-333c-43d6-8df5-9b2981992efc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

